### PR TITLE
QtPositioning is not required by our builds.

### DIFF
--- a/BinaryBuilder.py
+++ b/BinaryBuilder.py
@@ -763,7 +763,7 @@ class CMakePackage(Package):
 def print_qt_config(cppflags, config, bindir, includedir, libdir):
     '''Print out a bunch of QT stuff'''
     qt_pkgs = ('QtConcurrent QtCore QtGui QtNetwork QtSql QtSvg QtWidgets QtXml QtXmlPatterns QtPrintSupport QtTest'
-               + ' QtPositioning QtQml QtQuick QtOpenGL QtMultimedia QtMultimediaWidgets QtDBus')
+               + ' QtQml QtQuick QtOpenGL QtMultimedia QtMultimediaWidgets QtDBus')
     print('QT_ARBITRARY_MODULES="%s"' % qt_pkgs, file=config)
     qt_cppflags=[]
     qt_libs=['-L%s' % libdir]


### PR DESCRIPTION
I also disabled it in an earlier pull request.
https://github.com/NeoGeographyToolkit/BinaryBuilder/pull/12

Sorry, this is a minor follow up.